### PR TITLE
refactor!: rename to `@capawesome/capacitor-badge`

### DIFF
--- a/CapawesomeCapacitorBadge.podspec
+++ b/CapawesomeCapacitorBadge.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'RobingenzCapacitorBadge'
+  s.name = 'CapawesomeCapacitorBadge'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 <p align="center"><br><img src="https://user-images.githubusercontent.com/236501/85893648-1c92e880-b7a8-11ea-926d-95355b8175c7.png" width="128" height="128" /></p>
 <h3 align="center">Badge</h3>
-<p align="center"><strong><code>@robingenz/capacitor-badge</code></strong></p>
+<p align="center"><strong><code>@capawesome/capacitor-badge</code></strong></p>
 <p align="center">
   Capacitor plugin to access and update the badge number of the app icon.
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/maintenance/yes/2022?style=flat-square" />
-  <a href="https://github.com/robingenz/capacitor-badge/actions?query=workflow%3A%22CI%22"><img src="https://img.shields.io/github/workflow/status/robingenz/capacitor-badge/CI/main?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-badge"><img src="https://img.shields.io/npm/l/@robingenz/capacitor-badge?style=flat-square" /></a>
+  <a href="https://github.com/capawesome-team/capacitor-badge/actions?query=workflow%3A%22CI%22"><img src="https://img.shields.io/github/workflow/status/capawesome-team/capacitor-badge/CI/main?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-badge"><img src="https://img.shields.io/npm/l/@capawesome/capacitor-badge?style=flat-square" /></a>
 <br>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-badge"><img src="https://img.shields.io/npm/dw/@robingenz/capacitor-badge?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-badge"><img src="https://img.shields.io/npm/v/@robingenz/capacitor-badge?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all%20contributors-1-orange?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-badge"><img src="https://img.shields.io/npm/dw/@capawesome/capacitor-badge?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-badge"><img src="https://img.shields.io/npm/v/@capawesome/capacitor-badge?style=flat-square" /></a>
+  <a href="https://github.com/capawesome-team"><img src="https://img.shields.io/badge/part%20of-capawesome-%234f46e5?style=flat-square" /></a>
 </p>
 
 ## Maintainers
@@ -23,10 +21,18 @@
 | ---------- | ----------------------------------------- | --------------------------------------------- |
 | Robin Genz | [robingenz](https://github.com/robingenz) | [@robin_genz](https://twitter.com/robin_genz) |
 
+## Sponsors
+
+This is an MIT-licensed open source project. 
+It can grow thanks to the support by these awesome people. 
+If you'd like to join them, please read more [here](https://github.com/sponsors/capawesome-team).  
+
+<!-- sponsors --><!-- sponsors -->
+
 ## Installation
 
 ```bash
-npm install @robingenz/capacitor-badge
+npm install @capawesome/capacitor-badge
 npx cap sync
 ```
 
@@ -90,7 +96,7 @@ A working example can be found here: [robingenz/capacitor-plugin-demo](https://g
 ## Usage
 
 ```typescript
-import { Badge } from '@robingenz/capacitor-badge';
+import { Badge } from '@capawesome/capacitor-badge';
 
 const get = async () => {
   const result = await Badge.get();
@@ -296,8 +302,8 @@ On **Android** not all launchers support badges. This plugin uses [ShortcutBadge
 
 ## Changelog
 
-See [CHANGELOG.md](https://github.com/robingenz/capacitor-badge/blob/main/CHANGELOG.md).
+See [CHANGELOG.md](https://github.com/capawesome-team/capacitor-badge/blob/main/CHANGELOG.md).
 
 ## License
 
-See [LICENSE](https://github.com/robingenz/capacitor-badge/blob/main/LICENSE).
+See [LICENSE](https://github.com/capawesome-team/capacitor-badge/blob/main/LICENSE).

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.robingenz.capacitor.badge">
+    package="io.capawesome.capacitorjs.plugins.badge">
 </manifest>

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/Badge.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/Badge.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitor.badge;
+package io.capawesome.capacitorjs.plugins.badge;
 
 import static me.leolin.shortcutbadger.ShortcutBadger.isBadgeCounterSupported;
 

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgeConfig.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgeConfig.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitor.badge;
+package io.capawesome.capacitorjs.plugins.badge;
 
 public class BadgeConfig {
 

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitor.badge;
+package io.capawesome.capacitorjs.plugins.badge;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,22 @@
 {
-  "name": "@robingenz/capacitor-badge",
+  "name": "@capawesome/capacitor-badge",
   "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@robingenz/capacitor-badge",
+      "name": "@capawesome/capacitor-badge",
       "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robingenz/capacitor-badge",
+  "name": "@capawesome/capacitor-badge",
   "version": "1.2.1",
   "description": "Capacitor plugin to access and update the badge number of the app icon.",
   "main": "dist/plugin.cjs.js",
@@ -11,17 +11,27 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "RobingenzCapacitorBadge.podspec"
+    "CapawesomeCapacitorBadge.podspec"
   ],
   "author": "Robin Genz <mail@robingenz.dev>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/robingenz/capacitor-badge.git"
+    "url": "git+https://github.com/capawesome-team/capacitor-badge.git"
   },
   "bugs": {
-    "url": "https://github.com/robingenz/capacitor-badge/issues"
+    "url": "https://github.com/capawesome-team/capacitor-badge/issues"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/capawesome-team/"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/capawesome"
+    }
+  ],
   "keywords": [
     "capacitor",
     "plugin",
@@ -77,5 +87,8 @@
     "android": {
       "src": "android"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This plugin was renamed to `@capawesome/capacitor-badge`. Please install the new npm package and run `npx cap sync`.