### PR TITLE
fix(ios): `getConfigValue` is deprecated

### DIFF
--- a/ios/Plugin/BadgePlugin.swift
+++ b/ios/Plugin/BadgePlugin.swift
@@ -114,12 +114,8 @@ public class BadgePlugin: CAPPlugin {
     private func badgeConfig() -> BadgeConfig {
         var config = BadgeConfig()
 
-        if let persist = getConfigValue("persist") as? Bool {
-            config.persist = persist
-        }
-        if let autoClear = getConfigValue("autoClear") as? Bool {
-            config.autoClear = autoClear
-        }
+        config.persist = getConfig().getBoolean("persist", config.persist)
+        config.autoClear = getConfig().getBoolean("autoClear", config.autoClear)
 
         return config
     }


### PR DESCRIPTION
Closes #43 

Ref: https://github.com/ionic-team/capacitor-plugins/pull/962